### PR TITLE
possessive: its

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ mod test;
 
 pub use formatting::Formatting;
 
-/// Converts a number to it's written format, using "short" format.
+/// Converts a number to its written format, using "short" format.
 ///
 /// Arguments:
 /// * `val`: the `i64` to convert  
@@ -27,7 +27,7 @@ pub fn convert(val: i64, fmt: Formatting) -> String
         .build(fmt)
 }
 
-/// Converts a number to it's written format, using "short" format with all formatting options enabled.
+/// Converts a number to its written format, using "short" format with all formatting options enabled.
 ///
 /// # Arguments:
 /// * `val` - the `i64` to convert
@@ -38,7 +38,7 @@ pub fn convert_all_fmt(val: i64) -> String
         .build(Formatting::all())
 }
 
-/// Converts a number to it's written format, using "short" format with no formatting options enabled.
+/// Converts a number to its written format, using "short" format with no formatting options enabled.
 ///
 /// # Arguments:
 /// * `val` - the `i64` to convert
@@ -49,7 +49,7 @@ pub fn convert_no_fmt(val: i64) -> String
         .build(Formatting::none())
 }
 
-/// Converts a number to it's written format, using "long" format.
+/// Converts a number to its written format, using "long" format.
 ///
 /// # Arguments:
 /// * `val` - the `i64` to convert  


### PR DESCRIPTION
its (without apostrophe) is a possessive pronoun. In contrast, it’s (with apostrophe) is the shortened form, or contraction, of it is or it has.